### PR TITLE
Add gitignore to manage Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Byte-compiled / optimized / dependency cache
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+venv/
+.env/
+.venv/
+ENV/
+
+# Uploaded files
+uploads/
+
+# Database
+picscreenr.db


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore Python caches, virtual environments, uploads, and the database file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451fb606e4832eb9a4a33e4ac25279