### PR TITLE
Clarify Python version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,13 @@ A simple Flask application for uploading images, generating captions and tags, a
 
 ## Prerequisites
 
-- Python 3.8–3.11 are known to work with `dlib`; newer versions such as 3.13 may not yet provide prebuilt wheels.
-- On Windows, install Visual Studio Build Tools and CMake so that the `dlib` library required by `face_recognition` can compile.
+- Python 3.8–3.11 are known to work with `dlib`; newer versions such as 3.13
+  currently lack prebuilt wheels.  Using Python 3.11 or earlier is therefore
+  strongly recommended.
+- On Windows, make sure to use a 64‑bit Python and install Visual Studio
+  Build Tools as well as CMake so that the `dlib` library required by
+  `face_recognition` can compile.  An error like `python313t.lib` missing often
+  indicates an unsupported Python version.
 
 Verify CMake is accessible:
 ```bash


### PR DESCRIPTION
## Summary
- highlight that Python 3.13 isn't yet supported by dlib
- mention using a 64-bit Python and build tools if on Windows

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845285c875c832e85eecc1910f72467