### PR TITLE
Refactor DB session usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,100 +36,108 @@ caption_model, caption_processor, caption_tokenizer = load_caption_model()
 
 @app.post("/upload_image")
 def upload_image():
-    session = SessionLocal()
-    file = request.files.get("file")
-    if not file:
-        return jsonify({"error": "No file provided"}), 400
-    image = Image.open(file.stream).convert("RGB")
-    # normalize size
-    image = image.resize((512, 512))
-    safe_name = secure_filename(file.filename)
-    filename = os.path.join(app.config["UPLOAD_FOLDER"], safe_name)
-    image.save(filename)
+    with SessionLocal() as session:
+        with session.begin():
+            file = request.files.get("file")
+            if not file:
+                return jsonify({"error": "No file provided"}), 400
+            image = Image.open(file.stream).convert("RGB")
+            # normalize size
+            image = image.resize((512, 512))
+            safe_name = secure_filename(file.filename)
+            filename = os.path.join(app.config["UPLOAD_FOLDER"], safe_name)
+            image.save(filename)
 
-    caption = generate_caption(
-        caption_model, caption_processor, caption_tokenizer, filename
-    )
-    tags = extract_tags(caption)
-    image_record = ImageModel(filename=filename, caption=caption, tags=",".join(tags))
-    session.add(image_record)
-    session.commit()
+            caption = generate_caption(
+                caption_model, caption_processor, caption_tokenizer, filename
+            )
+            tags = extract_tags(caption)
+            image_record = ImageModel(
+                filename=filename, caption=caption, tags=",".join(tags)
+            )
+            session.add(image_record)
+            session.flush()
 
-    # face recognition
-    known_persons = session.query(Person).all()
-    known_embeddings = [pickle.loads(p.face_embedding) for p in known_persons]
-    face_embeddings = detect_faces(filename)
-    persons_in_image: List[PersonImage] = []
+            # face recognition
+            known_persons = session.query(Person).all()
+            known_embeddings = [pickle.loads(p.face_embedding) for p in known_persons]
+            face_embeddings = detect_faces(filename)
+            persons_in_image: List[PersonImage] = []
 
-    for embedding in face_embeddings:
-        idx, distance = compare_faces(known_embeddings, embedding)
-        if idx >= 0:
-            person = known_persons[idx]
-        else:
-            person = Person(face_embedding=pickle.dumps(embedding))
-            session.add(person)
-            session.commit()
-            known_persons.append(person)
-            known_embeddings.append(embedding)
-        link = PersonImage(
-            person_id=person.id, image_id=image_record.id, confidence=1 - distance
-        )
-        session.add(link)
-        persons_in_image.append(link)
+            for embedding in face_embeddings:
+                idx, distance = compare_faces(known_embeddings, embedding)
+                if idx >= 0:
+                    person = known_persons[idx]
+                else:
+                    person = Person(face_embedding=pickle.dumps(embedding))
+                    session.add(person)
+                    session.flush()
+                    known_persons.append(person)
+                    known_embeddings.append(embedding)
+                link = PersonImage(
+                    person_id=person.id, image_id=image_record.id, confidence=1 - distance
+                )
+                session.add(link)
+                persons_in_image.append(link)
 
-    # clothing features
-    feature_pairs = [
-        (p, pickle.loads(p.feature_vector)) for p in known_persons if p.feature_vector
-    ]
-    known_hists = [hist for _, hist in feature_pairs]
-    candidate_hist = extract_color_histogram(filename)
-    idx, score = compare_histograms(known_hists, candidate_hist)
-    if idx >= 0:
-        # index from compare_histograms maps to feature_pairs, not known_persons
-        person = feature_pairs[idx][0]
-        link = PersonImage(
-            person_id=person.id, image_id=image_record.id, confidence=score
-        )
-        session.add(link)
-        persons_in_image.append(link)
-    else:
-        # save histogram to new or existing person
-        if face_embeddings:
-            person = persons_in_image[0].person
-        else:
-            person = Person(feature_vector=pickle.dumps(candidate_hist))
-            session.add(person)
-            session.commit()
-        person.feature_vector = pickle.dumps(candidate_hist)
-        link = PersonImage(
-            person_id=person.id, image_id=image_record.id, confidence=score
-        )
-        session.add(link)
-        persons_in_image.append(link)
+            # clothing features
+            feature_pairs = [
+                (p, pickle.loads(p.feature_vector)) for p in known_persons if p.feature_vector
+            ]
+            known_hists = [hist for _, hist in feature_pairs]
+            candidate_hist = extract_color_histogram(filename)
+            idx, score = compare_histograms(known_hists, candidate_hist)
+            if idx >= 0:
+                # index from compare_histograms maps to feature_pairs, not known_persons
+                person = feature_pairs[idx][0]
+                link = PersonImage(
+                    person_id=person.id, image_id=image_record.id, confidence=score
+                )
+                session.add(link)
+                persons_in_image.append(link)
+            else:
+                # save histogram to new or existing person
+                if face_embeddings:
+                    person = persons_in_image[0].person
+                else:
+                    person = Person(feature_vector=pickle.dumps(candidate_hist))
+                    session.add(person)
+                    session.flush()
+                person.feature_vector = pickle.dumps(candidate_hist)
+                link = PersonImage(
+                    person_id=person.id, image_id=image_record.id, confidence=score
+                )
+                session.add(link)
+                persons_in_image.append(link)
 
-    session.commit()
-    return jsonify({"image_id": image_record.id, "caption": caption, "tags": tags})
+        return jsonify({"image_id": image_record.id, "caption": caption, "tags": tags})
 
 
 @app.get("/description/<int:image_id>")
 def get_description(image_id: int):
-    session = SessionLocal()
-    image_record = session.query(ImageModel).filter(ImageModel.id == image_id).first()
-    if not image_record:
-        return jsonify({"error": "Image not found"}), 404
-    return jsonify(
-        {"caption": image_record.caption, "tags": image_record.tags.split(",")}
-    )
+    with SessionLocal() as session:
+        image_record = (
+            session.query(ImageModel).filter(ImageModel.id == image_id).first()
+        )
+        if not image_record:
+            return jsonify({"error": "Image not found"}), 404
+        return jsonify(
+            {"caption": image_record.caption, "tags": image_record.tags.split(",")}
+        )
 
 
 @app.get("/identify/<int:image_id>")
 def identify(image_id: int):
-    session = SessionLocal()
-    links = session.query(PersonImage).filter(PersonImage.image_id == image_id).all()
-    result = []
-    for link in links:
-        result.append({"person_id": link.person_id, "confidence": link.confidence})
-    return jsonify({"persons": result})
+    with SessionLocal() as session:
+        links = (
+            session.query(PersonImage).filter(PersonImage.image_id == image_id).all()
+        )
+        result = []
+        for link in links:
+            result.append(
+                {"person_id": link.person_id, "confidence": link.confidence}
+            )
+        return jsonify({"persons": result})
 
 
 @app.get("/uploads/<path:filename>")


### PR DESCRIPTION
## Summary
- ensure DB sessions are always context managed
- use `session.begin()` for atomic writes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68453c8300ac832eadd6cc2863b1ef81